### PR TITLE
Add in a certified? method to detect certified cases

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -2,7 +2,8 @@ class CertificationsController < ApplicationController
   before_action :verify_authentication
 
   def new
-    render "mismatched_documents" unless appeal.ready_to_certify?
+    return render "already_certified" if appeal.certified?
+    return render "mismatched_documents" unless appeal.documents_match?
     @form8 = Form8.new_from_appeal(appeal)
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -18,7 +18,7 @@ class Appeal
   attr_accessor :vacols_id, :vbms_id
   attr_accessor :veteran_name, :appellant_name, :appellant_relationship, :vso_name
   attr_accessor :insurance_loan_number # => case_record.bfpdnum
-  attr_accessor :nod_date, :soc_date, :form9_date
+  attr_accessor :nod_date, :soc_date, :form9_date, :certification_date
 
   attr_writer :ssoc_dates
   def ssoc_dates
@@ -54,6 +54,10 @@ class Appeal
 
   def ssoc_all_match?
     ssoc_dates.all? { |date| ssoc_match?(date) }
+  end
+
+  def certified?
+    certification_date != nil
   end
 
   def ssoc_match?(date)

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -65,7 +65,7 @@ class Appeal
     ssoc_documents.any? { |doc| doc.received_at.to_date == date.to_date }
   end
 
-  def ready_to_certify?
+  def documents_match?
     nod_match? && soc_match? && form9_match? && ssoc_all_match?
   end
 

--- a/app/views/certifications/already_certified.html.erb
+++ b/app/views/certifications/already_certified.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>Mismatched Documents<% end %>
+
+<div class="usa-alert usa-alert-info cf-app-segment" role="alert">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Appeal has already been Certified</h3>
+    <p class="usa-alert-text">This case has already been certified to the Board.</p>
+  </div>
+</div>
+
+<div class="cf-app-segment cf-app-segment--alt">
+  <h2>Appeal has already been Certified</h2>
+
+  <p>
+    This case has already been certified to the Board. If this Case is a remand
+    being re-certified to the board, Caseflow is not currently able to
+    process remand cases.
+  </p>
+</div>
+
+<%#= render partial: 'cancel_cert_modal' %>

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -44,6 +44,23 @@ class Fakes::AppealRepository
     )
   end
 
+  def self.appeal_already_certified
+    Appeal.new(
+      type: :original,
+      file_type: :vbms,
+      vbms_id: "VBMS-ID",
+      vso_name: "Military Order of the Purple Heart",
+      nod_date: 3.days.ago,
+      soc_date: Date.new(1987, 9, 6),
+      certification_date: 1.day.ago,
+      form9_date: 1.day.ago,
+      documents: [nod_document, soc_document, form9_document],
+      veteran_name: "Davy Crockett",
+      appellant_name: "Susie Crockett",
+      appellant_relationship: "Daughter"
+    )
+  end
+
   def self.nod_document
     Document.new(type: :nod, received_at: 3.days.ago)
   end
@@ -60,7 +77,8 @@ class Fakes::AppealRepository
     unless Rails.env.test?
       self.records = {
         "123C" => Fakes::AppealRepository.appeal_ready_to_certify,
-        "456C" => Fakes::AppealRepository.appeal_not_ready
+        "456C" => Fakes::AppealRepository.appeal_not_ready,
+        "789C" => Fakes::AppealRepository.appeal_already_certified,
       }
     end
   end

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -78,7 +78,7 @@ class Fakes::AppealRepository
       self.records = {
         "123C" => Fakes::AppealRepository.appeal_ready_to_certify,
         "456C" => Fakes::AppealRepository.appeal_not_ready,
-        "789C" => Fakes::AppealRepository.appeal_already_certified,
+        "789C" => Fakes::AppealRepository.appeal_already_certified
       }
     end
   end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -79,4 +79,14 @@ describe Appeal do
       expect(subject.vacols_id).to eq("123C")
     end
   end
+
+  context "#certified?" do
+    subject { Appeal.new(certification_date: 2.days.ago) }
+
+    it "reads certification date off the appeal" do
+      expect(subject.certified?).to be_truthy
+      subject.certification_date = nil
+      expect(subject.certified?).to be_falsy
+    end
+  end
 end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1,5 +1,5 @@
 describe Appeal do
-  context "#ready_to_certify?" do
+  context "#documents_match?" do
     let(:nod_document) { Document.new(type: :nod, received_at: 3.days.ago) }
     let(:soc_document) { Document.new(type: :soc, received_at: 2.days.ago) }
     let(:form9_document) { Document.new(type: :form9, received_at: 1.day.ago) }
@@ -13,7 +13,7 @@ describe Appeal do
       )
     end
 
-    subject { appeal.ready_to_certify? }
+    subject { appeal.documents_match? }
 
     context "when there is an nod, soc, and form9 document matching the respective dates" do
       it { is_expected.to be_truthy }


### PR DESCRIPTION
In particular the certification_date being set means this case has
already been advanced. However, this will return *true* for remands,
since the certification date won't get re-set when re-certified to the
board.

Remands aren't covered in the current codebase, it's likely we'll need
a `remand?` method to handle that.


Related to https://github.com/department-of-veterans-affairs/caseflow-certification/issues/40, but does not close it yet.