### PR TITLE
Rollover `remarks` a lot of text is entered

### DIFF
--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Form8
   include ActiveModel::Model
   include ActiveModel::Conversion
@@ -40,6 +42,26 @@ class Form8
     :certifying_official_title,
     :certification_date
   ].freeze
+
+  REMARKS_SEE_PAGE_2 = " (see continued remarks page 2)".freeze
+  REMARKS_MAX_LENGTH = 159
+
+  def remarks_rollover?
+    return false if @remarks.nil?
+    @remarks.length > REMARKS_MAX_LENGTH + REMARKS_SEE_PAGE_2.length
+  end
+
+  def remarks_initial
+    if remarks_rollover?
+      "#{@remarks[0...REMARKS_MAX_LENGTH]}#{REMARKS_SEE_PAGE_2}"
+    else
+      @remarks
+    end
+  end
+
+  def remarks_continued
+    "\n\nContinued:\n#{@remarks[REMARKS_MAX_LENGTH...(@remarks.length)]}" if remarks_rollover?
+  end
 
   RECORD_TYPE_FIELDS = [
     { name: "CF OR XCF", attribute: :record_cf_or_xcf },

--- a/app/services/form8_pdf_service.rb
+++ b/app/services/form8_pdf_service.rb
@@ -2,7 +2,14 @@
 require "pdf_forms"
 
 class Form8PdfService
-  PDF_LOCATION_PREFIX = "form1[0].#subform[0].#area[0].".freeze
+  PDF_PAGE_1 = "form1[0].#subform[0].#area[0].".freeze
+  PDF_PAGE_2 = "form1[0].#subform[1].".freeze
+
+  # Currently, the only thing on Page 2 of the VA Form 8 is the continued
+  # remarks. As a result, we'll just say anything except for that is actually
+  # on Page 1.
+  FIELD_PAGES = Hash.new PDF_PAGE_1
+  FIELD_PAGES[:remarks_continued] = PDF_PAGE_2
 
   FIELD_LOCATIONS = {
     appellant_name: "TextField1[0]",
@@ -69,7 +76,8 @@ class Form8PdfService
     record_insurance_f: "CheckBox23[21]",
     record_other: "CheckBox23[28]",
     record_other_explaination: "TextField1[16]",
-    remarks: "TextField1[17]",
+    remarks_initial: "TextField1[17]",
+    remarks_continued: "TextField1[26]",
     certifying_office: "TextField1[18]",
     certifying_username: "TextField1[19]",
     certifying_official_name: "TextField1[20]",
@@ -88,7 +96,7 @@ class Form8PdfService
         value = PDF_CHECKBOX_SYMBOL
       end
 
-      location = PDF_LOCATION_PREFIX + location
+      location = FIELD_PAGES[attribute] + location
 
       pdf_values[location] = value
     end

--- a/spec/models/form8_spec.rb
+++ b/spec/models/form8_spec.rb
@@ -18,6 +18,24 @@ describe Form8 do
     end
   end
 
+  context "remarks rolls over" do
+    let(:appeal) { Form8.new(remarks: "Hello, World") }
+
+    it "rolls over remarks properly" do
+      expect(appeal.remarks).to eq("Hello, World")
+
+      expect(appeal.remarks_rollover?).to be_falsey
+      expect(appeal.remarks_initial).to eq("Hello, World")
+      expect(appeal.remarks_continued).to be_nil
+
+      appeal.remarks = "A" * 200 + "Hello, World!"
+
+      expect(appeal.remarks_rollover?).to be_truthy
+      expect(appeal.remarks_initial).to eq("A" * 159 + " (see continued remarks page 2)")
+      expect(appeal.remarks_continued).to eq("\n\nContinued:\n" + ("A" * 41) + "Hello, World!")
+    end
+  end
+
   context ".new_from_appeal" do
     before do
       Timecop.freeze


### PR DESCRIPTION
If we're given too much data in `remarks`, we now push it into the next
page, so that DROs feel free to write as much as they want.

This will add a notice to see remarks, and move the data down
transparently to the user.

Closes #45