### PR TITLE
Manually specify bundler directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ script:
 
 bundler_args: "--without development staging production"
 cache:
-  - bundler
+  directories:
+    - vendor/bundle
 
 notifications:
   email: false


### PR DESCRIPTION
From the travis build logs:
  Bundled gems are installed into ./vendor/bundle.

And then from travis cache instructions:
  https://docs.travis-ci.com/user/caching/#Determining-the-bundle-path

Since --deployment isn't present, it's picking the wrong directory causing constant cache misses.

An alternate to this CL is to pass --deployment into `bundler_args`