### PR TITLE
Use docker CI environment instead a full VM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 dist: wily
 rvm:
   - 2.3.0
+sudo: false  # Enable container based build environments.
 
 branches:
     only:


### PR DESCRIPTION
Must faster boot times (50s-145s -> 1-6s)  https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments.

Also, likely gives access to more build resources since this is now the majority supported configuration in Travis.