### PR TITLE
Hyperlink the mismatched instructions. Close #55

### DIFF
--- a/app/views/certifications/mismatched_documents.html.erb
+++ b/app/views/certifications/mismatched_documents.html.erb
@@ -16,7 +16,7 @@
   </p>
 
   <ul>
-    <li>The <strong>document type</strong> in VBMS to make sure it's labeled correctly</li>
+    <li>The <strong>document type</strong> in VBMS to make sure it's <a href="<%= help_path %>#mismatched-documents">labeled correctly</a></li>
     <li>The <strong>document date</strong> &#8212; the date in VBMS must match the date in VACOLS</li>
   </ul>
 

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -74,8 +74,8 @@
     [Screenshot of missing documents] 
     </p>
 
-    <h2>6. What are the reasons Caseflow may not be able to find documents
-    in VBMS?</h2>
+    <h2 id='mismatched-documents'>6. What are the reasons Caseflow may not be
+    able to find documents in VBMS?</h2>
 
     <p>
     There are usually three reasons Caseflow wouldn't be able to find a document:


### PR DESCRIPTION
This also reenforces the behavior of going to the help page when they
want specific details about how the app works.