### PR TITLE
Add a link to /help

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
             </a>
 
             <ul id="menu" class="cf-dropdown-menu" aria-labeledby="menu-trigger">
-              <li><a href="/TODO">Help</a></li>
+              <li><a href="/help">Help</a></li>
               <li><a href="https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx" target="_blank">Send Feedback</a></li>
               <li><a id="whats-new-item"<%if @show_whats_new_indicator%> class="cf-nav-whatsnew"<%end%> href="<%= url_for controller: 'whats_new', action: 'show'%>">What's New?</a></li>
               <li>


### PR DESCRIPTION
I didn't use `url_for`, `link_to` or any other helpers since they chocked. Chances are I need @shanear to figure out why they're all just returning `""`, my gut is that we're doing something weird with routes that's not doing reverse url lookups for the Help controller.