### PR TITLE
Don't pass an id to url_for sessions#destroy, closes #95

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
               <li><a href="https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx" target="_blank">Send Feedback</a></li>
               <li><a id="whats-new-item"<%if @show_whats_new_indicator%> class="cf-nav-whatsnew"<%end%> href="<%= url_for controller: 'whats_new', action: 'show'%>">What's New?</a></li>
               <li>
-                <a href="<%= url_for controller: 'sessions', action: 'destroy' %>">Sign out</a>
+                <a href="<%= url_for controller: 'sessions', action: 'destroy', id: nil %>">Sign out</a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
For some reason, rails will score sessions#show higher than #destroy if an id is specified.