### PR TITLE
Add in a Connect VBMS Error logger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,6 @@ Metrics/MethodLength:
 
 Metrics/ClassLength:
   Max: 400
+
+Metrics/AbcSize:
+  Max: 20

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -1,5 +1,19 @@
 require "vbms"
 
+class CaseflowLogger
+  def log(event, data)
+    case event
+    when :request
+      if data[:response_code] != 200
+        Rails.logger.error(
+          "VBMS HTTP Error #{data[:response_code]} " \
+          "(#{data[:request].class.name}) #{data[:response_body]}"
+        )
+      end
+    end
+  end
+end
+
 class AppealRepository
   FORM_8_DOC_TYPE_ID = 178
 
@@ -77,7 +91,8 @@ class AppealRepository
       vbms_config["key"],
       vbms_config["keypass"],
       vbms_config["cacert"],
-      vbms_config["cert"]
+      vbms_config["cert"],
+      logger: CaseflowLogger.new
     )
   end
 end


### PR DESCRIPTION
This will forward VBMS Webservice failures into the Rails log, so we can
align problems with our site with external service failures.