### PR TITLE
Alias root / to help page to be consistent with prod env, closes#177

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@ Rails.application.routes.draw do
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
-  # You can have the root of your site routed with "root"
-  root 'whats_new#show'
 
   # Example of regular route:
   #   get 'products/:id' => 'catalog#view'
@@ -27,6 +25,9 @@ Rails.application.routes.draw do
   get 'whats-new' => 'whats_new#show'
 
   get 'help' => 'help#show'
+
+  # alias root to help; make sure to keep this below the canonical route so url_for works
+  root 'help#show'
 
   mount PdfjsViewer::Rails::Engine => "/pdfjs", as: 'pdfjs'
 

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -81,6 +81,6 @@ RSpec.feature "Login" do
     fill_in "VACOLS Password", with: "pa55word!"
     click_on "Login"
 
-    expect(page).to have_content("Help")
+    expect(page).to have_content("Caseflow Certification Help")
   end
 end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -81,6 +81,6 @@ RSpec.feature "Login" do
     fill_in "VACOLS Password", with: "pa55word!"
     click_on "Login"
 
-    expect(page).to have_content("What’s New?")
+    expect(page).to have_content("Help")
   end
 end


### PR DESCRIPTION
Before this it was impossible to access /whats-new because url_for was mapping it to root (because it appeared in routes.rb above the canonical definition).

This pull

1. Aliases root to /help to be consistent with other environments
2. Defines the alias after the canonical url so url_for returns /help instead of /