### PR TITLE
rollover logs every MB, retain 10

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,6 +44,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
+  # roll logger over every 1MB, retain 10
+  config.logger = Logger.new(config.paths["log"].first, 10, 1.megabytes)
+
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -36,6 +36,9 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  # roll logger over every 1MB, retain 10
+  config.logger = Logger.new(config.paths["log"].first, 10, 1.megabytes)
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
This should be deployed to a non-prod environment and verified before promoting to production.