### PR TITLE
Display build version in html comment and as hover text

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,7 +103,7 @@
 
   <footer class="cf-txt-c usa-grid cf-app-footer">
     <div class="cf-push-left">
-      <span<% if Rails.application.config.build_version %> title="<%= (Rails.application.config.build_version || {} )[:date] %>"<% end %>>Built</span> with <abbr title="love">&#9825;</abbr> by the
+      <span<% if Rails.application.config.build_version %> title="<%= Rails.application.config.build_version[:date] %>"<% end %>>Built</span> with <abbr title="love">&#9825;</abbr> by the
       <a href="http://www.va.gov/ds/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>.
     </div>
     <div class="cf-push-right">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,10 +103,9 @@
 
   <footer class="cf-txt-c usa-grid cf-app-footer">
     <div class="cf-push-left">
-      Built with <abbr title="love">&#9825;</abbr> by the
+      <span<% if Rails.application.config.build_version %> title="<%= (Rails.application.config.build_version || {} )[:date] %>"<% end %>>Built</span> with <abbr title="love">&#9825;</abbr> by the
       <a href="http://www.va.gov/ds/">Digital Service at the <abbr title="Department of Veterans Affairs">VA</abbr></a>.
     </div>
-
     <div class="cf-push-right">
       <a target="_blank" href="https://vaww.vaco.portal.va.gov/sites/BVA/olkm/DigitalService/Lists/Feedback/NewForm.aspx">
         Send feedback
@@ -115,3 +114,6 @@
   </footer>
 </body>
 </html>
+<% if Rails.application.config.build_version %>
+    <!-- <%= Rails.application.config.build_version.to_s.html_safe %> -->
+<% end %>

--- a/config/initializers/build_version.rb
+++ b/config/initializers/build_version.rb
@@ -1,0 +1,4 @@
+file_path = Rails.root + "config/build_version.yml"
+raw_config = File.exists?(file_path) ? File.read(file_path) : ""
+config = YAML.load(raw_config)
+Rails.application.config.build_version = config ? config.symbolize_keys : nil


### PR DESCRIPTION
Display build version:

* An HTML comment at bottom of page
* Hover (title) text over the word "built" in footer. 


Related to https://github.com/department-of-veterans-affairs/deployment/pull/226, but either can be deployed independently. 
 
![build-version](https://cloud.githubusercontent.com/assets/16327036/14048553/4c03c928-f285-11e5-83b2-b76d78db0048.png)