### PR TITLE
Don't save form8 with large values in session

### DIFF
--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -33,16 +33,9 @@ class CertificationsController < ApplicationController
 
   def create
     @form8 = Form8.new(params[:form8])
-    serialized_form8 = @form8.attributes
 
-    # rough estimate
-    serialized_length = serialized_form8.to_s.bytesize
+    session[:form8] = @form8.attributes if @form8.fits_in_cookie?
 
-    if serialized_length <= 3.kilobytes
-      session[:form8] = serialized_form8
-    else
-      logger.warn "unable to serialize form; length #{serialized_length} exceeds maximum"
-    end
     form8.save!
     redirect_to certification_path(id: form8.id)
   end

--- a/app/controllers/certifications_controller.rb
+++ b/app/controllers/certifications_controller.rb
@@ -33,7 +33,16 @@ class CertificationsController < ApplicationController
 
   def create
     @form8 = Form8.new(params[:form8])
-    session[:form8] = @form8.attributes
+    serialized_form8 = @form8.attributes
+
+    # rough estimate
+    serialized_length = serialized_form8.to_s.bytesize
+
+    if serialized_length <= 3.kilobytes
+      session[:form8] = serialized_form8
+    else
+      logger.warn "unable to serialize form; length #{serialized_length} exceeds maximum"
+    end
     form8.save!
     redirect_to certification_path(id: form8.id)
   end

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -128,8 +128,8 @@ class Form8
 
     max_size_bytes = 3.kilobytes
 
-    Rails.logger.warn("serialized form exceeds maximum length of #{max_size_bytes};" /
-                          " length #{size_bytes} exceeds maximum") if size_bytes > max_size_bytes
+    Rails.logger.warn("serialized form exceeds maximum length of #{max_size_bytes}; " \
+     "length #{size_bytes} exceeds maximum") if size_bytes > max_size_bytes
 
     size_bytes <= max_size_bytes
   end

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -120,6 +120,20 @@ class Form8
     end
   end
 
+  def fits_in_cookie?
+    serialized_form8 = attributes
+
+    # rough estimate
+    size_bytes = serialized_form8.to_s.bytesize
+
+    max_size_bytes = 3.kilobytes
+
+    Rails.logger.warn("serialized form exceeds maximum length of #{max_size_bytes};" /
+                          " length #{size_bytes} exceeds maximum") if size_bytes > max_size_bytes
+
+    size_bytes <= max_size_bytes
+  end
+
   def representative
     type = representative_type == "Other" ? representative_type_specify_other : representative_type
     "#{representative_name} - #{type}"

--- a/app/views/certifications/new.html.erb
+++ b/app/views/certifications/new.html.erb
@@ -44,7 +44,7 @@
 
     <div class="cf-form-cond-req">
       <%= f.text_area :service_connection_for,
-            question_number: "5A", label: "Service connection for:" %>
+            question_number: "5A", label: "Service connection for:", maxlength: 5500 %>
 
       <%= f.date_field :service_connection_notification_date,
             question_number: "5B", label: "Date of notification of action appealed:" %>
@@ -52,7 +52,7 @@
 
     <div class="cf-form-cond-req">
       <%= f.text_area :increased_rating_for,
-            question_number: "6A", label: "Increased rating for:" %>
+            question_number: "6A", label: "Increased rating for:", maxlength: 138 %>
 
       <%= f.date_field :increased_rating_notification_date,
             question_number: "6B", label: "Date of notification of action appealed:" %>
@@ -60,10 +60,10 @@
 
     <div class="cf-form-cond-req">
       <%= f.text_area :other_for,
-            question_number: "7A", label: "Other:" %>
+            question_number: "7A", label: "Other:", maxlength: 138 %>
 
       <%= f.date_field :other_notification_date,
-            question_number: "7B", label: "Date of notification of action appealed:" %>
+            question_number: "7B", label: "Date of notification of action appealed:", maxlength: 138 %>
     </div>
 
     <%= f.radio_buttons_field :representative_type,
@@ -121,7 +121,7 @@
           question_number: "13", part: "2", label: "Specify other:", secondary: true %>
 
     <%= f.text_area :remarks,
-          question_number: "14", label: "Remarks:" %>
+          question_number: "14", label: "Remarks:", maxlength: 5500 %>
 
     <%= f.text_field :certifying_office,
           question_number: "15", label: "Name and location of certifying office:", readonly: true %>

--- a/spec/models/form8_spec.rb
+++ b/spec/models/form8_spec.rb
@@ -115,6 +115,18 @@ describe Form8 do
     end
   end
 
+  context "#fits_in_cookie?" do
+    it "returns false if contents exceed 3kb" do
+      form = Form8.new(remarks: "a" * 4.kilobytes)
+      expect(form.fits_in_cookie?).to be_falsey
+    end
+
+    it "returns true if contents do not exceed 3kb" do
+      form = Form8.new(remarks: "a" * 1.kilobyte)
+      expect(form.fits_in_cookie?).to be_truthy
+    end
+  end
+
   context ".from_appeal" do
     before do
       Timecop.freeze


### PR DESCRIPTION
Also adds maxlength to textarea fields so we don't accept values that can't fit in form8 anyway.

I suspect that guessing the serialized length via hash.to_s to too restrictive but this will at least prevent us from exceeding 4kb cookie limit. 

I've also tried GZipping/base64 encoding the values but that doesn't help. A better solution would be to override rails cookie store and gzip there.

Closes #230