### PR TITLE
Use Rails Memory Cache for saved form8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 
 # Ignore OSX .DS_Store files
 .DS_Store
+
+.idea/*

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -117,21 +117,7 @@ class Form8
 
     (record_attrs + FORM_FIELDS + [:version]).each_with_object({}) do |field, result|
       result[field] = send(field)
-    end
-  end
-
-  def fits_in_cookie?
-    serialized_form8 = attributes
-
-    # rough estimate
-    size_bytes = serialized_form8.to_s.bytesize
-
-    max_size_bytes = 3.kilobytes
-
-    Rails.logger.warn("serialized form exceeds maximum length of #{max_size_bytes}; " \
-     "length #{size_bytes} exceeds maximum") if size_bytes > max_size_bytes
-
-    size_bytes <= max_size_bytes
+    end.stringify_keys
   end
 
   def representative

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,5 +26,7 @@ module CaseflowCertification
     config.autoload_paths << Rails.root.join('lib')
     config.autoload_paths << Rails.root.join('services')
     config.exceptions_app = self.routes
+
+    config.cache_store = :memory_store, {expires_in: 24.hours, size: 256.megabytes}
   end
 end

--- a/spec/models/form8_spec.rb
+++ b/spec/models/form8_spec.rb
@@ -115,18 +115,6 @@ describe Form8 do
     end
   end
 
-  context "#fits_in_cookie?" do
-    it "returns false if contents exceed 3kb" do
-      form = Form8.new(remarks: "a" * 4.kilobytes)
-      expect(form.fits_in_cookie?).to be_falsey
-    end
-
-    it "returns true if contents do not exceed 3kb" do
-      form = Form8.new(remarks: "a" * 1.kilobyte)
-      expect(form.fits_in_cookie?).to be_truthy
-    end
-  end
-
   context ".from_appeal" do
     before do
       Timecop.freeze


### PR DESCRIPTION
* Remove cookie logic and related tests
* Configure in-memory `Rails.cache` on app startup
* Keeps login info in the cookie to maintain backwards compatibility

Future enhancements: 
* Save more than one form8 per session by modifying `form8_cache_key` and specifying the `vacols_id`

Closes #235, closes #233 (obsolete)