### PR TITLE
Change wording to determine the type of hearing

### DIFF
--- a/app/views/certifications/new.html.erb
+++ b/app/views/certifications/new.html.erb
@@ -92,7 +92,7 @@
           question_number: "9B", label: "Why is the Form 646 not of record?" %>
 
     <%= f.yes_no_field :hearing_requested,
-          question_number: "10A", label: "Was hearing requested?" %>
+          question_number: "10A", label: "Was BVA hearing requested?" %>
 
     <%= f.yes_no_field :hearing_held,
           question_number: "10B", part: "1", label: "Was the hearing held?" %>

--- a/spec/feature/save_certification_spec.rb
+++ b/spec/feature/save_certification_spec.rb
@@ -59,7 +59,7 @@ RSpec.feature "Save Certification" do
     within_fieldset("8A Representative Type") do
       find("label", text: "Attorney").click
     end
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       find("label", text: "No").click
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
@@ -79,7 +79,7 @@ RSpec.feature "Save Certification" do
     within_fieldset("8A Representative Type") do
       expect(find_field("Attorney", visible: false)).to be_checked
     end
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       expect(find_field("No", visible: false)).to be_checked
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
@@ -107,7 +107,7 @@ RSpec.feature "Save Certification" do
     within_fieldset("8A Representative Type") do
       find("label", text: "Attorney").click
     end
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       find("label", text: "No").click
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
@@ -138,7 +138,7 @@ RSpec.feature "Save Certification" do
     within_fieldset("8A Representative Type") do
       find("label", text: "Attorney").click
     end
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       find("label", text: "No").click
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do
@@ -185,14 +185,14 @@ RSpec.feature "Save Certification" do
     end
 
     # Validate hidden values don't submit
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       find("label", text: "Yes").click
     end
     within_fieldset("10B Was the hearing held?") do
       find("label", text: "Yes").click
     end
     fill_in "10C If requested, but not held, explain", with: "i'm going to disappear"
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       find("label", text: "No").click
     end
 
@@ -250,7 +250,7 @@ RSpec.feature "Save Certification" do
     within_fieldset("8A Representative Type") do
       find("label", text: "Attorney").click
     end
-    within_fieldset("10A Was hearing requested?") do
+    within_fieldset("10A Was BVA hearing requested?") do
       find("label", text: "No").click
     end
     within_fieldset("11A Are contested claims procedures applicable in this case?") do


### PR DESCRIPTION
For RO hearings, the hearing was likely already held, so the ROs only
check yes if it is a BVA hearing. As such, let's clarify what kind of
hearing we're asking for. This was feedback heard from multiple folks;
including Boston.