### PR TITLE
make sure log_formatter isn't obliterated when creating new logger

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -17,7 +17,15 @@ config = Rails.application.config
 config.log_tags = log_tags
 
 # roll logger over every 1MB, retain 10
-logger_path = config.paths["log"].first
-rollover_logger = Logger.new(logger_path, 10, 1.megabyte)
-Rails.logger = ActiveSupport::TaggedLogging.new(rollover_logger) unless Rails.env.development?
+unless Rails.env.development?
+  logger_path = config.paths["log"].first
+  rollover_logger = Logger.new(logger_path, 10, 1.megabyte)
+  Rails.logger = rollover_logger
+
+  # set the format again in case it was overwritten
+  Rails.logger.formatter = config.log_formatter if config.log_formatter
+
+  # recreate the logger with Tagged support which Rails expects
+  Rails.logger = ActiveSupport::TaggedLogging.new(Rails.logger)
+end
 # :nocov:


### PR DESCRIPTION
See https://github.com/department-of-veterans-affairs/caseflow-efolder/issues/125 for report of original problem.