### PR TITLE
Add health-check resource for use in a load balancer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
   private
 
   def ssl_enabled?
-    Rails.env.production?
+    Rails.env.production? && !(request.path =~ /health-check/)
   end
 
   def strict_transport_security

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,9 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
+  force_ssl if: :ssl_enabled?
+  before_action :strict_transport_security
+
   before_action :set_timezone,
                 :setup_fakes,
                 :check_whats_new_cookie
@@ -23,6 +26,14 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def ssl_enabled?
+    Rails.env.production?
+  end
+
+  def strict_transport_security
+    response.headers["Strict-Transport-Security"] = "max-age=31536000; includeSubDomains" if request.ssl?
+  end
 
   def not_found
     render "errors/404", layout: "application", status: 404

--- a/app/controllers/health_checks_controller.rb
+++ b/app/controllers/health_checks_controller.rb
@@ -1,0 +1,8 @@
+class HealthChecksController < ApplicationController
+  skip_before_action :authenticate
+  skip_before_action :authorize
+
+  def show
+    render text: "Application server is healthy!"
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -41,9 +41,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
-
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
   config.log_level = :debug

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,8 @@
 # Be sure to restart your server when you modify this file.
+options = {
+  key: '_caseflow-certification_session',
+  secure: Rails.env.production?,
+  expire_after: 2.weeks
+}
 
-Rails.application.config.session_store :cookie_store, key: '_caseflow-certification_session', expire_after: 2.weeks
+Rails.application.config.session_store :cookie_store, options

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   end
   resources :offices, only: :index
 
+  get "health-check", to: "health_checks#show"
   get "login" => "sessions#new"
   get "logout" => "sessions#destroy"
   post "auth/saml_callback" => "sessions#ssoi_saml_callback"


### PR DESCRIPTION
* Break up Rails `config.force_ssl` into its 3 components:
  - Force all access to the app over SSL, 
  - use Strict-Transport-Security, 
  - and use secure cookies.
* Add a health-check resource that is exempt from forced SSL and authorization

Fixes #303