### PR TITLE
Allow System Admins to certify appeals

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,7 @@ class User
   def can?(thing)
     return true unless css?
     return false if roles.nil?
+    return true if roles.include? "System Admin"
     roles.include? thing
   end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -17,8 +17,7 @@ test:
   secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
 
 staging:
-  secret_key_base: 8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862
-
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] || "8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862" %>
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:


### PR DESCRIPTION
also make it easier to run locally connected to CSS (using a setable secret key)