### PR TITLE
Log IP of instance, HTTP request host

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -4,14 +4,16 @@ def get_session(req)
 end
 
 # :nocov:
-log_tags = []
-log_tags << lambda { |req|
+ip = IPSocket.getaddress(Socket.gethostname)
+logged_in_user = lambda { |req|
   session = get_session(req)
   username = session["username"]
   nil unless username
   ro = session["regional_office"]
   ro ? "#{username} (#{ro})" : username
 }
+
+log_tags = [:host, ip, logged_in_user]
 
 config = Rails.application.config
 config.log_tags = log_tags


### PR DESCRIPTION
Adds 2 new log tags to output:

* HTTP request host (the domain that was requested)
* IP address of machine serving request

Also initializes `log_tags` variable as an array literal instead of appending via `<<`.

Sample output
```
I, [2016-10-17T13:31:34.995518 #29281]  INFO -- : [uat.caseflow.ds.va.gov] [172.xxx] Redirected to https://uat.caseflow.ds.va.gov/auth/samlva
```