### PR TITLE
Get logged in user from CSS session attribute

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -7,7 +7,7 @@ end
 ip = IPSocket.getaddress(Socket.gethostname)
 logged_in_user = lambda { |req|
   session = get_session(req)
-  username = session["username"]
+  username = session["user"] ? session["user"]["id"] : session["username"]
   nil unless username
   ro = session["regional_office"]
   ro ? "#{username} (#{ro})" : username


### PR DESCRIPTION
This works but duplicates logic from the `User` model. Alternate solutions:

* Invoke `User.from_session` but this would unnecessarily parse the `User` object again every time a message is logged. 
* Memoize the parsed `User` object in request scope (does Rails have that?) use in both `logger.rb` and `application_controller.rb`

Fixes #343