### PR TITLE
Adding caseflow logo homepage link

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -69,7 +69,9 @@
   <header>
     <nav class="cf-nav">
       <div class="usa-grid-full">
-        <h1 class="cf-logo"><span class="cf-logo-image"></span>Caseflow</h1>
+        <a href="/">
+          <h1 class="cf-logo"><span class="cf-logo-image"></span>Caseflow</h1>
+        </a>
         <h2 id="page-title" class="cf-application-title"><%= yield :page_title %></h2>
 
         <% unless current_user.nil? %>


### PR DESCRIPTION
Fixes #282 

The logo now links to the homepage.

**Test Plan**
- Run the test suite.
-Navigate to a page and click the new homepage link.
![screen shot 2016-10-26 at 11 39 25 am](https://cloud.githubusercontent.com/assets/3885236/19733093/0091bd70-9b71-11e6-94f4-309d8f660541.png)
