### PR TITLE
uses localhost where env is not production

### DIFF
--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -4,7 +4,7 @@ def get_session(req)
 end
 
 # :nocov:
-ip = IPSocket.getaddress(Socket.gethostname)
+ip = Rails.env.production?  ? IPSocket.getaddress(Socket.gethostname) : 'localhost'
 logged_in_user = lambda { |req|
   session = get_session(req)
   username = session["user"] ? session["user"]["id"] : session["username"]

--- a/config/initializers/logger.rb
+++ b/config/initializers/logger.rb
@@ -4,7 +4,7 @@ def get_session(req)
 end
 
 # :nocov:
-ip = Rails.env.production?  ? IPSocket.getaddress(Socket.gethostname) : 'localhost'
+ip = Rails.env.production? ? IPSocket.getaddress(Socket.gethostname) : 'localhost'
 logged_in_user = lambda { |req|
   session = get_session(req)
   username = session["user"] ? session["user"]["id"] : session["username"]


### PR DESCRIPTION
My local machine doesn't resolve `hostname` to my IP, which causes logger.rb to crash. Ideally, I'd figure out why! But it appears that we don't have any use for this info in dev envs anyway.

Testing:
Caseflow works locally