### PR TITLE
Adds screen reader only link to download Form 8 PDF, and another screen reader only link to skip iframe

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -34,10 +34,10 @@
 // Screen reader only content is not generally recommended,
 // so only use this to resolve major technical hurdles.
 .off-screen {
-  position:absolute;
-  left:-10000px;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 }

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -27,3 +27,17 @@
     .bar { fill: $color-secondary; }
   }
 }
+
+// This class will place an element off screen without
+// affecting its placement in tab order, thus making it
+// invisible onscreen but read out by screen readers.
+// Screen reader only content is not generally recommended,
+// so only use this to resolve major technical hurdles.
+.off-screen {
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}

--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -27,17 +27,3 @@
     .bar { fill: $color-secondary; }
   }
 }
-
-// This class will place an element off screen without
-// affecting its placement in tab order, thus making it
-// invisible onscreen but read out by screen readers.
-// Screen reader only content is not generally recommended,
-// so only use this to resolve major technical hurdles.
-.off-screen {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}

--- a/app/views/certifications/show.html.erb
+++ b/app/views/certifications/show.html.erb
@@ -11,7 +11,7 @@
 affecting its placement in tab order, thus making it invisible onscreen
 but read out by screen readers. -->
 
-<a class="usa-sr-only" href="<%= pdf_certification_path(id: form8.id, time: Time.now.to_i) %>" download target="_blank">"The PDF viewer in your browser may not be accessible. Click to download the Form 8 PDF so you can preview it in a reader with accessibility features such as Adobe Acrobat.</a>
+<a class="usa-sr-only" id="sr-download-link" href="<%= pdf_certification_path(id: form8.id, time: Time.now.to_i) %>" download target="_blank">"The PDF viewer in your browser may not be accessible. Click to download the Form 8 PDF so you can preview it in a reader with accessibility features such as Adobe Acrobat.</a>
 <a class="usa-sr-only" href="#certification-buttons"> If you are using a screen reader and have downloaded and verified the Form 8 PDF, click this link to skip past the browser PDF viewer to the certification buttons.</a>
 
 <iframe aria-label="The PDF embedded here is not accessible. Please use the above link to download the PDF and view it in a PDF reader. Then use the buttons below to go back and make edits or upload and certify the document."class="cf-doc-embed cf-app-segment" title="Form8 PDF"

--- a/app/views/certifications/show.html.erb
+++ b/app/views/certifications/show.html.erb
@@ -7,10 +7,12 @@
   </p>
 </div>
 
-<!-- This link is here for 508 compliance, and shouldn't be visible to sighted users. We need to allow non-sighted users to preview the Form 8. Adobe Acrobat is the accessibility standard and is used across gov't, so we'll recommend it for now.  -->
+<!-- This link is here for 508 compliance, and shouldn't be visible to sighted users. We need to allow non-sighted users to preview the Form 8. Adobe Acrobat is the accessibility standard and is used across gov't, so we'll recommend it for now. The usa-sr-only class will place an element off screen without
+affecting its placement in tab order, thus making it invisible onscreen
+but read out by screen readers. -->
 
-<a class="off-screen" href="<%= pdf_certification_path(id: form8.id, time: Time.now.to_i) %>" download target="_blank">"The PDF viewer in your browser may not be accessible. Click to download the Form 8 PDF so you can preview it in a reader with accessibility features such as Adobe Acrobat.</a>
-<a class="off-screen" href="#certification-buttons"> If you are using a screen reader and have downloaded and verified the Form 8 PDF, click this link to skip past the browser PDF viewer to the certification buttons.</a>
+<a class="usa-sr-only" href="<%= pdf_certification_path(id: form8.id, time: Time.now.to_i) %>" download target="_blank">"The PDF viewer in your browser may not be accessible. Click to download the Form 8 PDF so you can preview it in a reader with accessibility features such as Adobe Acrobat.</a>
+<a class="usa-sr-only" href="#certification-buttons"> If you are using a screen reader and have downloaded and verified the Form 8 PDF, click this link to skip past the browser PDF viewer to the certification buttons.</a>
 
 <iframe aria-label="The PDF embedded here is not accessible. Please use the above link to download the PDF and view it in a PDF reader. Then use the buttons below to go back and make edits or upload and certify the document."class="cf-doc-embed cf-app-segment" title="Form8 PDF"
   src="<%= pdfjs.full_path(file: pdf_certification_path(id: form8.id, time: Time.now.to_i)) %>"></iframe>

--- a/app/views/certifications/show.html.erb
+++ b/app/views/certifications/show.html.erb
@@ -10,7 +10,7 @@
 <!-- This link is here for 508 compliance, and shouldn't be visible to sighted users. We need to allow non-sighted users to preview the Form 8. Adobe Acrobat is the accessibility standard and is used across gov't, so we'll recommend it for now.  -->
 
 <a class="off-screen" href="<%= pdf_certification_path(id: form8.id, time: Time.now.to_i) %>" download target="_blank">"The PDF viewer in your browser may not be accessible. Click to download the Form 8 PDF so you can preview it in a reader with accessibility features such as Adobe Acrobat.</a>
-<a class="off-screen" href="#certification-buttons"> If you are using a screen reader, click this link to skip past the browser PDF viewer to the certification buttons.</a>
+<a class="off-screen" href="#certification-buttons"> If you are using a screen reader and have downloaded and verified the Form 8 PDF, click this link to skip past the browser PDF viewer to the certification buttons.</a>
 
 <iframe aria-label="The PDF embedded here is not accessible. Please use the above link to download the PDF and view it in a PDF reader. Then use the buttons below to go back and make edits or upload and certify the document."class="cf-doc-embed cf-app-segment" title="Form8 PDF"
   src="<%= pdfjs.full_path(file: pdf_certification_path(id: form8.id, time: Time.now.to_i)) %>"></iframe>

--- a/app/views/certifications/show.html.erb
+++ b/app/views/certifications/show.html.erb
@@ -7,10 +7,15 @@
   </p>
 </div>
 
-<iframe class="cf-doc-embed cf-app-segment" title="Form8 PDF"
+<!-- This link is here for 508 compliance, and shouldn't be visible to sighted users. We need to allow non-sighted users to preview the Form 8. Adobe Acrobat is the accessibility standard and is used across gov't, so we'll recommend it for now.  -->
+
+<a class="off-screen" href="<%= pdf_certification_path(id: form8.id, time: Time.now.to_i) %>" download target="_blank">"The PDF viewer in your browser may not be accessible. Click to download the Form 8 PDF so you can preview it in a reader with accessibility features such as Adobe Acrobat.</a>
+<a class="off-screen" href="#certification-buttons"> If you are using a screen reader, click this link to skip past the browser PDF viewer to the certification buttons.</a>
+
+<iframe aria-label="The PDF embedded here is not accessible. Please use the above link to download the PDF and view it in a PDF reader. Then use the buttons below to go back and make edits or upload and certify the document."class="cf-doc-embed cf-app-segment" title="Form8 PDF"
   src="<%= pdfjs.full_path(file: pdf_certification_path(id: form8.id, time: Time.now.to_i)) %>"></iframe>
 
-<div class="cf-form cf-app-segment">
+<div class="cf-form cf-app-segment" id="certification-buttons">
   <%= loading_indicator %>
 
   <button type="button" class="usa-button-gray cf-action-back cf-push-left" onclick="window.history.back()">

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -39,6 +39,6 @@ RSpec.feature "Confirm Certification" do
     # We want this content to only appear for screen reader users, so
     # it will not be visible, but it **should** be in the DOM.
     expect(page).to have_content("The PDF viewer in your browser may not be accessible.")
-    expect(page).to have_css('.off-screen', :visible => false)
+    expect(page).to have_css(".off-screen", visible: false)
   end
 end

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Confirm Certification" do
   end
 
   scenario "Visiting certification page as a sighted user" do
-    certification = Certification.create!(vacols_id: "5555C")
+    Certification.create!(vacols_id: "5555C")
     visit "certifications/5555C"
     # We want this content to only appear for screen reader users, so
     # it will not be visible, but it **should** be in the DOM.

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -15,6 +15,22 @@ RSpec.feature "Confirm Certification" do
 
   after { Timecop.return }
 
+  scenario "Successful screen reader visit of pdf link" do
+    Certification.create!(vacols_id: "5555C")
+    visit "certifications/5555C"
+    # We want this content to only appear for screen reader users, so
+    # it will not be visible, but it **should** be in the DOM.
+    expect(page).to have_content("The PDF viewer in your browser may not be accessible.")
+    expect(page).to have_css(".usa-sr-only", visible: false)
+    # Sending click or keypress events to elements that are not in the DOM doesn't seem to work,
+    # so let's find the hidden link's href and visit it manually to check that the pdf can be
+    # found there.
+    pdf_href = page.find('#sr-download-link')["href"]
+    visit(pdf_href)
+    content_header = page.response_headers["Content-Disposition"]
+    expect(content_header.include?("form8-TEST.pdf")).to be true
+  end
+
   scenario "Successful confirmation" do
     visit "certifications/5555C"
     expect(page).to have_content("Review Form 8")
@@ -28,17 +44,9 @@ RSpec.feature "Confirm Certification" do
   scenario "Successful confirmation with certification record" do
     certification = Certification.create!(vacols_id: "5555C")
     visit "certifications/5555C"
-    click_on "Upload and certify"
 
+    click_on "Upload and certify"
     expect(certification.reload.completed_at).to eq(Time.zone.now)
   end
 
-  scenario "Visiting certification page as a sighted user" do
-    Certification.create!(vacols_id: "5555C")
-    visit "certifications/5555C"
-    # We want this content to only appear for screen reader users, so
-    # it will not be visible, but it **should** be in the DOM.
-    expect(page).to have_content("The PDF viewer in your browser may not be accessible.")
-    expect(page).to have_css(".off-screen", visible: false)
-  end
 end

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -15,19 +15,22 @@ RSpec.feature "Confirm Certification" do
 
   after { Timecop.return }
 
-  scenario "Successful screen reader visit of pdf link" do
+  scenario "Screen reader user visits pdf link" do
     Certification.create!(vacols_id: "5555C")
     visit "certifications/5555C"
     # We want this content to only appear for screen reader users, so
     # it will not be visible, but it **should** be in the DOM.
+
     expect(page).to have_content("The PDF viewer in your browser may not be accessible.")
     expect(page).to have_css(".usa-sr-only", visible: false)
+
     # Sending click or keypress events to elements that are not in the DOM doesn't seem to work,
     # so let's find the hidden link's href and visit it manually to check that the pdf can be
     # found there.
     pdf_href = page.find('#sr-download-link')["href"]
     visit(pdf_href)
     content_header = page.response_headers["Content-Disposition"]
+
     expect(content_header.include?("form8-TEST.pdf")).to be true
   end
 
@@ -44,9 +47,8 @@ RSpec.feature "Confirm Certification" do
   scenario "Successful confirmation with certification record" do
     certification = Certification.create!(vacols_id: "5555C")
     visit "certifications/5555C"
-
     click_on "Upload and certify"
+
     expect(certification.reload.completed_at).to eq(Time.zone.now)
   end
-
 end

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Confirm Certification" do
     certification = Certification.create!(vacols_id: "5555C")
     visit "certifications/5555C"
     # We want this content to only appear for screen reader users, so
-    # it will not be visible, but it SHOULD be in the DOM.
+    # it will not be visible, but it **should** be in the DOM.
     expect(page).to have_content("The PDF viewer in your browser may not be accessible.")
     expect(page).to have_css('.off-screen', :visible => false)
   end

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature "Confirm Certification" do
     expect(certification.reload.completed_at).to eq(Time.zone.now)
   end
 
-  scenario "Visiting certification page as a sighted user", focus: true do
+  scenario "Visiting certification page as a sighted user" do
     certification = Certification.create!(vacols_id: "5555C")
     visit "certifications/5555C"
     # We want this content to only appear for screen reader users, so

--- a/spec/feature/confirm_certification_spec.rb
+++ b/spec/feature/confirm_certification_spec.rb
@@ -32,4 +32,13 @@ RSpec.feature "Confirm Certification" do
 
     expect(certification.reload.completed_at).to eq(Time.zone.now)
   end
+
+  scenario "Visiting certification page as a sighted user", focus: true do
+    certification = Certification.create!(vacols_id: "5555C")
+    visit "certifications/5555C"
+    # We want this content to only appear for screen reader users, so
+    # it will not be visible, but it SHOULD be in the DOM.
+    expect(page).to have_content("The PDF viewer in your browser may not be accessible.")
+    expect(page).to have_css('.off-screen', :visible => false)
+  end
 end


### PR DESCRIPTION
Adds screen reader only content since our browser PDF viewer doesn't display the content in an accessible way.

Fixes #354 
