### PR TITLE
Recreate VACOLS full grant and remand reports for EP

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -13,8 +13,8 @@ class Appeal
   attr_accessor :certification_date
   attr_accessor :notification_date, :nod_date, :soc_date, :form9_date
   attr_accessor :type
-  attr_accessor :merged
-  attr_accessor :appeal_disposition
+  attr_accessor :disposition
+  attr_accessor :decision_date
   attr_accessor :file_type
   attr_accessor :case_record
 
@@ -177,8 +177,8 @@ class Appeal
         regional_office_key: case_record.bfregoff,
         certification_date: case_record.bf41stat,
         case_record: case_record,
-        merged: case_record.bfdc == "M",
-        appeal_disposition: VACOLS::Case::DISPOSITIONS[case_record.bfdc]
+        disposition: VACOLS::Case::DISPOSITIONS[case_record.bfdc],
+        decision_date: normalize_vacols_date(case_record.bfddec)
       )
     end
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -14,6 +14,7 @@ class Appeal
   attr_accessor :notification_date, :nod_date, :soc_date, :form9_date
   attr_accessor :type
   attr_accessor :merged
+  attr_accessor :appeal_disposition
   attr_accessor :file_type
   attr_accessor :case_record
 
@@ -176,7 +177,8 @@ class Appeal
         regional_office_key: case_record.bfregoff,
         certification_date: case_record.bf41stat,
         case_record: case_record,
-        merged: case_record.bfdc == "M"
+        merged: case_record.bfdc == "M",
+        appeal_disposition: VACOLS::Case::DISPOSITIONS[case_record.bfdc]
       )
     end
   end

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -86,7 +86,7 @@ class VACOLS::Case < VACOLS::Record
 
   # These scopes query VACOLS and cannot be covered by automated tests.
   # :nocov:
-  def self.remands_for_ep
+  def self.remands_for_claims_establishment
     VACOLS::Case.includes(:folder, :correspondent).where("
 
       BFMPRO = 'REM'
@@ -98,7 +98,7 @@ class VACOLS::Case < VACOLS::Record
     ")
   end
 
-  def self.fullgrants_for_ep(decided_after)
+  def self.full_grants_for_claims_establishment(decided_after)
     VACOLS::Case.joins(:folder, :correspondent).where(%{
 
       BFDC = '1'

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -85,6 +85,8 @@ class VACOLS::Case < VACOLS::Record
     "6" => :video_hearing
   }.freeze
 
+  # These scopes query VACOLS and cannot be covered by automated tests.
+  # :nocov:
   def self.remands_for_ep
     VACOLS::Case.includes(:folder, :correspondent).where("
 
@@ -114,4 +116,5 @@ class VACOLS::Case < VACOLS::Record
 
     }, starttime.strftime("%Y-%m-%d %H:%M"))
   end
+  # :nocov:
 end

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -38,8 +38,7 @@ class VACOLS::Case < VACOLS::Record
     "R" => "Reconsideration by Letter",
     "V" => "Motion to Vacate Withdrawn",
     "W" => "Withdrawn from Remand",
-    "X" => "Remand Failure to Respond",
-    nil => nil
+    "X" => "Remand Failure to Respond"
   }.freeze
 
   REPRESENTATIVES = {
@@ -99,7 +98,7 @@ class VACOLS::Case < VACOLS::Record
     ")
   end
 
-  def self.fullgrants_for_ep(starttime)
+  def self.fullgrants_for_ep(decided_after)
     VACOLS::Case.joins(:folder, :correspondent).where(%{
 
       BFDC = '1'
@@ -114,7 +113,7 @@ class VACOLS::Case < VACOLS::Record
       and BFSO <> 'T'
       -- Exclude cases with a private attorney.
 
-    }, starttime.strftime("%Y-%m-%d %H:%M"))
+    }, decided_after.strftime("%Y-%m-%d %H:%M"))
   end
   # :nocov:
 end

--- a/app/models/vacols/case.rb
+++ b/app/models/vacols/case.rb
@@ -100,10 +100,10 @@ class VACOLS::Case < VACOLS::Record
   def self.fullgrants_for_ep(starttime)
     VACOLS::Case.joins(:folder, :correspondent).where(%{
 
-      BFDC = 1
+      BFDC = '1'
       -- Cases marked with the disposition Allowed - at least one grant, no remands.
 
-      and BFDDEC > to_date('?', 'YYYY-MM-DD HH24:MI')
+      and BFDDEC > to_date(?, 'YYYY-MM-DD HH24:MI')
       -- As all full grants are in HIST status, we must time bracket our requests.
 
       and (TIVBMS = 'Y' or TISUBJ2 = 'Y')

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -25,6 +25,18 @@ class AppealRepository
     create_appeal(case_record)
   end
 
+  def self.ready_for_end_product(starttime)
+    remands = MetricsService.timer "loaded remands in loc 97 from VACOLS" do
+      VACOLS::CASE.remands_for_ep
+    end
+
+    fullgrants = MetricsService.timer "loaded full grants decided after #{starttime} from VACOLS" do
+      VACOLS::CASE.fullgrants_for_ep(starttime)
+    end
+
+    (remands + fullgrants).map { |case_record| create_appeal(case_record) }
+  end
+
   def self.create_appeal(case_record)
     appeal = Appeal.from_records(
       case_record: case_record,

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -25,16 +25,20 @@ class AppealRepository
     create_appeal(case_record)
   end
 
-  def self.ready_for_end_product(starttime)
+  def self.remands_for_end_product
     remands = MetricsService.timer "loaded remands in loc 97 from VACOLS" do
       VACOLS::CASE.remands_for_ep
     end
 
-    fullgrants = MetricsService.timer "loaded full grants decided after #{starttime} from VACOLS" do
-      VACOLS::CASE.fullgrants_for_ep(starttime)
+    remands.map { |case_record| create_appeal(case_record) }
+  end
+
+  def self.fullgrants_for_end_product(decided_after)
+    fullgrants = MetricsService.timer "loaded full grants decided after #{decided_after} from VACOLS" do
+      VACOLS::CASE.fullgrants_for_ep(decided_after)
     end
 
-    (remands + fullgrants).map { |case_record| create_appeal(case_record) }
+    fullgrants.map { |case_record| create_appeal(case_record) }
   end
 
   def self.create_appeal(case_record)

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -22,26 +22,26 @@ class AppealRepository
       VACOLS::Case.includes(:folder, :correspondent).find(vacols_id)
     end
 
-    create_appeal(case_record)
+    build_appeal(case_record)
   end
 
-  def self.remands_for_claims_establishment
+  def self.remands_ready_for_claims_establishment
     remands = MetricsService.timer "loaded remands in loc 97 from VACOLS" do
-      VACOLS::CASE.remands_for_claims_establishment
+      VACOLS::CASE.remands_ready_for_claims_establishment
     end
 
-    remands.map { |case_record| create_appeal(case_record) }
+    remands.map { |case_record| build_appeal(case_record) }
   end
 
-  def self.full_grants_for_claims_establishment(decided_after)
-    fullgrants = MetricsService.timer "loaded full grants decided after #{decided_after} from VACOLS" do
-      VACOLS::CASE.full_grants_for_claims_establishment(decided_after)
+  def self.amc_full_grants(decided_after:)
+    full_grants = MetricsService.timer "loaded AMC full grants decided after #{decided_after} from VACOLS" do
+      VACOLS::CASE.amc_full_grants(decided_after)
     end
 
-    fullgrants.map { |case_record| create_appeal(case_record) }
+    full_grants.map { |case_record| build_appeal(case_record) }
   end
 
-  def self.create_appeal(case_record)
+  def self.build_appeal(case_record)
     appeal = Appeal.from_records(
       case_record: case_record,
       folder_record: case_record.folder,

--- a/app/services/appeal_repository.rb
+++ b/app/services/appeal_repository.rb
@@ -25,17 +25,17 @@ class AppealRepository
     create_appeal(case_record)
   end
 
-  def self.remands_for_end_product
+  def self.remands_for_claims_establishment
     remands = MetricsService.timer "loaded remands in loc 97 from VACOLS" do
-      VACOLS::CASE.remands_for_ep
+      VACOLS::CASE.remands_for_claims_establishment
     end
 
     remands.map { |case_record| create_appeal(case_record) }
   end
 
-  def self.fullgrants_for_end_product(decided_after)
+  def self.full_grants_for_claims_establishment(decided_after)
     fullgrants = MetricsService.timer "loaded full grants decided after #{decided_after} from VACOLS" do
-      VACOLS::CASE.fullgrants_for_ep(decided_after)
+      VACOLS::CASE.full_grants_for_claims_establishment(decided_after)
     end
 
     fullgrants.map { |case_record| create_appeal(case_record) }

--- a/app/services/full_grants_report.rb
+++ b/app/services/full_grants_report.rb
@@ -26,11 +26,11 @@ class FullGrantsReport < Report
   end
 
   def find_records
-    VACOLS::Case.full_grants_for_claims_establishment(7.days.ago)
+    VACOLS::Case.amc_full_grants(decided_after: 7.days.ago)
   end
 
   def load_record(case_record)
-    AppealRepository.create_appeal(case_record)
+    AppealRepository.build_appeal(case_record)
   end
 
   def include_record?(_appeal)

--- a/app/services/full_grants_report.rb
+++ b/app/services/full_grants_report.rb
@@ -1,6 +1,6 @@
-class FullgrantsReport < Report
+class FullGrantsReport < Report
   def self.output_filename
-    "fullgrants"
+    "full_grants"
   end
 
   def self.table_columns
@@ -26,7 +26,7 @@ class FullgrantsReport < Report
   end
 
   def find_records
-    VACOLS::Case.fullgrants_for_ep(7.days.ago)
+    VACOLS::Case.full_grants_for_claims_establishment(7.days.ago)
   end
 
   def load_record(case_record)

--- a/app/services/fullgrants_report.rb
+++ b/app/services/fullgrants_report.rb
@@ -1,0 +1,42 @@
+class FullgrantsReport < Report
+  def self.output_filename
+    "fullgrants"
+  end
+
+  def self.table_columns
+    [
+      "Appeal Id",
+      "Name",
+      "RO",
+      "Decision Date",
+      "Disposition",
+      "Representative"
+    ]
+  end
+
+  def self.table_row(appeal)
+    [
+      appeal.case_record.bfkey,
+      "#{appeal.veteran_first_name} #{appeal.veteran_last_name}",
+      appeal.regional_office_name,
+      appeal.decision_date,
+      appeal.disposition,
+      appeal.representative
+    ]
+  end
+
+  def find_records
+    VACOLS::Case.fullgrants_for_ep(7.days.ago)
+  end
+
+  def load_record(case_record)
+    AppealRepository.create_appeal(case_record)
+  end
+
+  def include_record?(_appeal)
+    true
+  end
+
+  def cleanup_record(_appeal)
+  end
+end

--- a/app/services/mismatch_report.rb
+++ b/app/services/mismatch_report.rb
@@ -158,7 +158,7 @@ class MismatchReport < Report
   end
 
   def load_record(case_record)
-    AppealRepository.create_appeal(case_record)
+    AppealRepository.build_appeal(case_record)
   end
 
   def include_record?(appeal)

--- a/app/services/mismatch_report.rb
+++ b/app/services/mismatch_report.rb
@@ -37,7 +37,7 @@ class MismatchReport < Report
       bool_str(appeal.case_record.bfdcertool),
       bool_str(appeal.hearing_pending?),
       appeal.vbms_id,
-      bool_str(appeal.merged),
+      bool_str(appeal.disposition == "Merged Appeal"),
       nod_date_alternatives(appeal),
       soc_date_alternatives(appeal),
       form9_date_alternatives(appeal),

--- a/app/services/remands_report.rb
+++ b/app/services/remands_report.rb
@@ -26,11 +26,11 @@ class RemandsReport < Report
   end
 
   def find_records
-    VACOLS::Case.remands_for_claims_establishment
+    VACOLS::Case.remands_ready_for_claims_establishment
   end
 
   def load_record(case_record)
-    AppealRepository.create_appeal(case_record)
+    AppealRepository.build_appeal(case_record)
   end
 
   def include_record?(_appeal)

--- a/app/services/remands_report.rb
+++ b/app/services/remands_report.rb
@@ -1,0 +1,42 @@
+class RemandsReport < Report
+  def self.output_filename
+    "remands"
+  end
+
+  def self.table_columns
+    [
+      "Appeal Id",
+      "Name",
+      "RO",
+      "Decision Date",
+      "Disposition",
+      "Representative"
+    ]
+  end
+
+  def self.table_row(appeal)
+    [
+      appeal.case_record.bfkey,
+      "#{appeal.veteran_first_name} #{appeal.veteran_last_name}",
+      appeal.regional_office_name,
+      appeal.decision_date,
+      appeal.disposition,
+      appeal.representative
+    ]
+  end
+
+  def find_records
+    VACOLS::Case.remands_for_ep
+  end
+
+  def load_record(case_record)
+    AppealRepository.create_appeal(case_record)
+  end
+
+  def include_record?(_appeal)
+    true
+  end
+
+  def cleanup_record(_appeal)
+  end
+end

--- a/app/services/remands_report.rb
+++ b/app/services/remands_report.rb
@@ -26,7 +26,7 @@ class RemandsReport < Report
   end
 
   def find_records
-    VACOLS::Case.remands_for_ep
+    VACOLS::Case.remands_for_claims_establishment
   end
 
   def load_record(case_record)

--- a/app/services/seam_report.rb
+++ b/app/services/seam_report.rb
@@ -29,7 +29,7 @@ class SeamReport < Report
       appeal.certification_date,
       bool_str(appeal.hearing_pending?),
       appeal.vbms_id,
-      bool_str(appeal.merged)
+      bool_str(appeal.disposition == "Merged Appeal")
     ]
   end
 

--- a/app/services/seam_report.rb
+++ b/app/services/seam_report.rb
@@ -80,7 +80,7 @@ class SeamReport < Report
   end
 
   def load_record(case_record)
-    AppealRepository.create_appeal(case_record)
+    AppealRepository.build_appeal(case_record)
   end
 
   def include_record?(appeal)

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -20,11 +20,11 @@ class Fakes::AppealRepository
     record
   end
 
-  def self.remands_for_claims_establishment
+  def self.remands_ready_for_claims_establishment
     [@records["321C"]]
   end
 
-  def self.full_grants_for_claims_establishment(decided_after)
+  def self.amc_full_grants(decided_after:)
     [@records["654C"]].select { |appeal| appeal.decision_date > decided_after }
   end
 

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -10,7 +10,7 @@ class Fakes::AppealRepository
   end
 
   def self.find(id)
-    # timing a hash access is unnecessery but this adds coverage to MetricsService in dev mode
+    # timing a hash access is unnecessary but this adds coverage to MetricsService in dev mode
     record = MetricsService.timer "load appeal #{id}" do
       @records[id]
     end
@@ -18,6 +18,9 @@ class Fakes::AppealRepository
     fail VBMSError if !record.nil? && RAISE_VBMS_ERROR_ID == record.vbms_id
 
     record
+  end
+
+  def self.ready_for_end_product(starttime)
   end
 
   def self.appeal_ready_to_certify

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -20,11 +20,11 @@ class Fakes::AppealRepository
     record
   end
 
-  def self.remands_for_end_product
+  def self.remands_for_claims_establishment
     [@records["321C"]]
   end
 
-  def self.fullgrants_for_end_product(decided_after)
+  def self.full_grants_for_claims_establishment(decided_after)
     [@records["654C"]].select { |appeal| appeal.decision_date > decided_after }
   end
 
@@ -139,7 +139,7 @@ class Fakes::AppealRepository
     )
   end
 
-  def self.appeal_fullgrant_decided
+  def self.appeal_full_grant_decided
     Appeal.new(
       type: "Post Remand",
       disposition: "Allowed",
@@ -185,7 +185,7 @@ class Fakes::AppealRepository
         "456C" => Fakes::AppealRepository.appeal_mismatched_docs,
         "789C" => Fakes::AppealRepository.appeal_already_certified,
         "321C" => Fakes::AppealRepository.appeal_remand_decided,
-        "654C" => Fakes::AppealRepository.appeal_fullgrant_decided,
+        "654C" => Fakes::AppealRepository.appeal_full_grant_decided,
         "000ERR" => Fakes::AppealRepository.appeal_raises_vbms_error,
         "001ERR" => Fakes::AppealRepository.appeal_missing_data
       }

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -20,14 +20,12 @@ class Fakes::AppealRepository
     record
   end
 
-  def self.ready_for_end_product(starttime)
-    remands = [@records["321C"]]
+  def self.remands_for_end_product
+    [@records["321C"]]
+  end
 
-    fullgrants = [@records["654C"]].select do |appeal|
-      appeal.decision_date > starttime
-    end
-
-    remands + fullgrants
+  def self.fullgrants_for_end_product(decided_after)
+    [@records["654C"]].select { |appeal| appeal.decision_date > decided_after }
   end
 
   def self.appeal_ready_to_certify

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -21,6 +21,13 @@ class Fakes::AppealRepository
   end
 
   def self.ready_for_end_product(starttime)
+    remands = [@records["321C"]]
+
+    fullgrants = [@records["654C"]].select do |appeal|
+      appeal.decision_date > starttime
+    end
+
+    remands + fullgrants
   end
 
   def self.appeal_ready_to_certify
@@ -121,6 +128,32 @@ class Fakes::AppealRepository
     )
   end
 
+  def self.appeal_remand_decided
+    Appeal.new(
+      type: "Original",
+      disposition: "Remanded",
+      decision_date: 7.days.ago,
+      veteran_first_name: "Davy",
+      veteran_last_name: "Crockett",
+      appellant_first_name: "Susie",
+      appellant_last_name: "Crockett",
+      appellant_relationship: "Daughter"
+    )
+  end
+
+  def self.appeal_fullgrant_decided
+    Appeal.new(
+      type: "Post Remand",
+      disposition: "Allowed",
+      decision_date: 7.days.ago,
+      veteran_first_name: "Davy",
+      veteran_last_name: "Crockett",
+      appellant_first_name: "Susie",
+      appellant_last_name: "Crockett",
+      appellant_relationship: "Daughter"
+    )
+  end
+
   RAISE_VBMS_ERROR_ID = "raise_vbms_error_id".freeze
 
   def self.appeal_raises_vbms_error
@@ -153,6 +186,8 @@ class Fakes::AppealRepository
         "123C" => Fakes::AppealRepository.appeal_ready_to_certify,
         "456C" => Fakes::AppealRepository.appeal_mismatched_docs,
         "789C" => Fakes::AppealRepository.appeal_already_certified,
+        "321C" => Fakes::AppealRepository.appeal_remand_decided,
+        "654C" => Fakes::AppealRepository.appeal_fullgrant_decided,
         "000ERR" => Fakes::AppealRepository.appeal_raises_vbms_error,
         "001ERR" => Fakes::AppealRepository.appeal_missing_data
       }

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -10,4 +10,16 @@ namespace :reports do
     Rails.application.eager_load!
     MismatchReport.new.run!
   end
+
+  desc "Run the full grants report"
+  task grants: [:environment] do
+    Rails.application.eager_load!
+    FullgrantsReport.new.run!
+  end
+
+  desc "Run the remands report"
+  task remands: [:environment] do
+    Rails.application.eager_load!
+    RemandsReport.new.run!
+  end
 end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -14,7 +14,7 @@ namespace :reports do
   desc "Run the full grants report"
   task grants: [:environment] do
     Rails.application.eager_load!
-    FullgrantsReport.new.run!
+    FullGrantsReport.new.run!
   end
 
   desc "Run the remands report"

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -95,7 +95,8 @@ describe Appeal do
         bfha: "6",
         bfhr: "1",
         bfregoff: "DSUSER",
-        bfdc: "M"
+        bfdc: "9",
+        bfddec: 1.day.ago
       )
     end
 
@@ -151,7 +152,8 @@ describe Appeal do
         hearing_requested: true,
         hearing_held: true,
         regional_office_key: "DSUSER",
-        merged: true
+        disposition: "Withdrawn",
+        decision_date: Appeal.normalize_vacols_date(1.day.ago)
       )
     end
 


### PR DESCRIPTION
fixes #352.

@shanear @joofsh: Mind taking a look at this? Will this dovetail with what you're planning?

One interesting discovery: not everything in remand status (`BFMPRO = 'REM'`) is marked as a remand by disposition (`BFDC`). Unfortunately, that means that the approach here, discussed with Shane, of `AppealRepository.ready_for_end_product` returning both remands and full grants, means that we don't currently have a way to distinguish the two. We'll need to add more information to the `appeal` model to do so. Hanging onto `BFMPRO` would do the trick. Or we could abandon concatenating remands and full grants together into a single method.