### PR TITLE
Ensure vbms documents are fetched for certification

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -104,6 +104,10 @@ class Appeal < ActiveRecord::Base
     Appeal.certify(self)
   end
 
+  def fetch_documents!
+    self.class.repository.fetch_documents_for(self)
+  end
+
   class << self
      attr_writer :repository
      delegate :certify, to: :repository

--- a/app/models/certification.rb
+++ b/app/models/certification.rb
@@ -25,8 +25,14 @@ class Certification < ActiveRecord::Base
     update_attributes!(completed_at: Time.zone.now)
   end
 
+  # TODO(jd): Consider lazy loading documents like
+  # VACOLS attributes
   def appeal
-    @appeal ||= Appeal.find_or_create_by_vacols_id(vacols_id)
+    @appeal ||= begin
+      appeal = Appeal.find_or_create_by_vacols_id(vacols_id)
+      appeal.fetch_documents!
+      appeal
+    end
   end
 
   def form8(cache_key)

--- a/lib/fakes/appeal_repository.rb
+++ b/lib/fakes/appeal_repository.rb
@@ -24,8 +24,9 @@ class Fakes::AppealRepository
     appeal.assign_from_vacols(record)
   end
 
-  def self.fetch_documents_for(_appeal)
-    @documents || []
+  def self.fetch_documents_for(appeal)
+    return unless appeal.documents.blank?
+    appeal.documents = @documents || []
   end
 
   def self.remands_ready_for_claims_establishment
@@ -185,6 +186,10 @@ class Fakes::AppealRepository
 
   def self.form9_document
     Document.new(type: "Form 9", received_at: 1.day.ago)
+  end
+
+  def self.set_vbms_documents!
+    @documents = [nod_document, soc_document, form9_document]
   end
 
   def self.seed!

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -17,7 +17,25 @@ describe Certification do
     Appeal.repository.stub(:load_vacols_data) {}
   end
 
-  after { Timecop.return }
+  after do
+    Timecop.return
+    Fakes::AppealRepository.documents = nil
+  end
+
+  context "#appeal", focus: true do
+    subject { certification.appeal }
+    before do
+      Fakes::AppealRepository.set_vbms_documents!
+    end
+
+    it "includes documents" do
+      expect(subject.documents).to_not be_empty
+
+      expect_any_instance_of(Appeal).to_not receive(:fetch_documents!).at_least(1).times
+      # test it doesn't fetch documents a 2nd time
+      subject
+    end
+  end
 
   context "#start!" do
     subject { certification.start! }

--- a/spec/models/certification_spec.rb
+++ b/spec/models/certification_spec.rb
@@ -22,7 +22,7 @@ describe Certification do
     Fakes::AppealRepository.documents = nil
   end
 
-  context "#appeal", focus: true do
+  context "#appeal" do
     subject { certification.appeal }
     before do
       Fakes::AppealRepository.set_vbms_documents!


### PR DESCRIPTION
To summarize the bug:
- Originally before the Appeals/AppealsRepository refactor in https://github.com/department-of-veterans-affairs/caseflow-certification/pull/397 , `AppealRepository.find` would fetch the appeal from VACOLS and (indirectly) load all documents from vbms. In this refactor we abstracted out the vbms document fetching to a separate method so that we could only make the VBMS request if/when needed
- Refactor failed to make the call to fetch VBMS documents in the known case of certification, which _does_ need documents upfront
- Tests stub out this integration, so the missing call was not noticed.

Testing:
- [x] Added tests that went from Red => Green based on the above code changes
- [ ] Manually testing after merge on UAT CC @shanear @orischwartz 