### PR TITLE
Initial case worker index

### DIFF
--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -1,0 +1,3 @@
+.task-start-cta {
+  text-align: center
+}

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -1,3 +1,10 @@
+@import 'caseflow_main';
+
+.task-start-wrapper {
+  padding: 20px 0 40px;
+  border-bottom: 2px solid $color-gray-lighter;
+}
+
 .task-start-cta {
   text-align: center
 }

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -6,5 +6,5 @@
 }
 
 .task-start-cta {
-  text-align: center
+  text-align: center;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -11,4 +11,5 @@
  * file per style scope.
  *
  *= require _main.scss
+ *= require _tasks.scss
  */

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -7,6 +7,15 @@ class TasksController < ApplicationController
 
   private
 
+  def next_unassigned_task
+    @next_unassigned_task ||= scoped_tasks.unassigned.first
+  end
+  helper_method :next_unassigned_task
+
+  def scoped_tasks
+    Task.find_by_department(department).newest_first
+  end
+
   def department
     params[:department]
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,8 +6,15 @@ class Task < ActiveRecord::Base
     dispatch: [:CreateEndProduct]
   }.freeze
 
-  def self.find_by_department(department)
+  scope :unassigned,          -> { where(user_id: nil) }
+  scope :newest_first,        -> { order(created_at: :desc) }
+  scope :find_by_department,  ->(department) do
     task_types = TASKS_BY_DEPARTMENT[department]
     where(type: task_types)
+  end
+
+
+  def start_text
+    type.titlecase
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -21,7 +21,6 @@ class Task < ActiveRecord::Base
     end
   end
 
-
   def start_text
     type.titlecase
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,11 +6,19 @@ class Task < ActiveRecord::Base
     dispatch: [:CreateEndProduct]
   }.freeze
 
-  scope :unassigned,          -> { where(user_id: nil) }
-  scope :newest_first,        -> { order(created_at: :desc) }
-  scope :find_by_department,  ->(department) do
-    task_types = TASKS_BY_DEPARTMENT[department]
-    where(type: task_types)
+  class << self
+    def unassigned
+      where(user_id: nil)
+    end
+
+    def newest_first
+      order(created_at: :desc)
+    end
+
+    def find_by_department(department)
+      task_types = TASKS_BY_DEPARTMENT[department]
+      where(type: task_types)
+    end
   end
 
 

--- a/app/views/tasks/worker_index.html.erb
+++ b/app/views/tasks/worker_index.html.erb
@@ -1,1 +1,9 @@
-<h1>Worker View</h1>
+<div class="cf-app-segment cf-app-segment--alt">
+  <% if next_unassigned_task %>
+    <div class="task-start-cta">
+      <button type="button" class="usa-button-primary">
+        <%= next_unassigned_task.start_text %>
+      </button>
+    </div>
+  <% end %>
+</div>

--- a/app/views/tasks/worker_index.html.erb
+++ b/app/views/tasks/worker_index.html.erb
@@ -1,5 +1,5 @@
 <div class="cf-app-segment cf-app-segment--alt">
-  <div class="usa-width-one-whole">
+  <div class="usa-width-one-whole task-start-wrapper">
     <% if next_unassigned_task %>
       <div class="task-start-cta">
         <button type="button" class="usa-button-primary">

--- a/app/views/tasks/worker_index.html.erb
+++ b/app/views/tasks/worker_index.html.erb
@@ -1,9 +1,11 @@
 <div class="cf-app-segment cf-app-segment--alt">
-  <% if next_unassigned_task %>
-    <div class="task-start-cta">
-      <button type="button" class="usa-button-primary">
-        <%= next_unassigned_task.start_text %>
-      </button>
-    </div>
-  <% end %>
+  <div class="usa-width-one-whole">
+    <% if next_unassigned_task %>
+      <div class="task-start-cta">
+        <button type="button" class="usa-button-primary">
+          <%= next_unassigned_task.start_text %>
+        </button>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,11 +24,11 @@ class SeedDB
   end
 
   def create_tasks(number)
-    numAppeals = @appeals.length
-    numUsers = @users.length
+    num_appeals = @appeals.length
+    num_users = @users.length
     @tasks = number.times.map do |i|
-      CreateEndProduct.create(appeal: @appeals[i % numAppeals],
-                              user: @users[i % numUsers])
+      CreateEndProduct.create(appeal: @appeals[i % num_appeals],
+                              user: @users[i % (num_users + 1)])
     end
   end
 

--- a/spec/feature/dispatch_spec.rb
+++ b/spec/feature/dispatch_spec.rb
@@ -1,10 +1,12 @@
 RSpec.feature "Dispatch" do
   before do
     reset_application!
-    User.authenticate!(roles: ['dispatch'])
-    appeal = Appeal.create(
-      Fakes::AppealRepository.appeal_remand_decided.merge(vacols_id: "123C")
-    )
+    User.authenticate!(roles: ["dispatch"])
+    Fakes::AppealRepository.records = {
+      "123C" => Fakes::AppealRepository.appeal_remand_decided
+    }
+
+    appeal = Appeal.create(vacols_id: "123C")
     CreateEndProduct.create(appeal: appeal)
   end
 
@@ -13,6 +15,4 @@ RSpec.feature "Dispatch" do
 
     expect(page).to have_content("Create End Product")
   end
-
 end
-

--- a/spec/feature/dispatch_spec.rb
+++ b/spec/feature/dispatch_spec.rb
@@ -1,0 +1,18 @@
+RSpec.feature "Dispatch" do
+  before do
+    reset_application!
+    User.authenticate!(roles: ['dispatch'])
+    appeal = Appeal.create(
+      Fakes::AppealRepository.appeal_remand_decided.merge(vacols_id: "123C")
+    )
+    CreateEndProduct.create(appeal: appeal)
+  end
+
+  scenario "Case Worker" do
+    visit "/dispatch"
+
+    expect(page).to have_content("Create End Product")
+  end
+
+end
+

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,11 +1,40 @@
 describe Task do
+  before do
+    reset_application!
+  end
+
   context ".find_by_department" do
     let(:department) { :dispatch }
     subject { Task.find_by_department(department) }
 
     it "filters to tasks in the department" do
       expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
-      expect(subject.to_sql).to include("CreateEndProduct")
+      expect(subject.to_sql).to include("\"tasks\".\"type\" = 'CreateEndProduct'")
+    end
+  end
+
+  context ".newest_first" do
+    subject { Task.newest_first }
+    before do
+      appeal = Appeal.create(vacols_id: "123C")
+      appeal2 = Appeal.create(vacols_id: "456D")
+      @oldest = CreateEndProduct.create(appeal: appeal, created_at: 10.days.ago)
+      @newest = CreateEndProduct.create(appeal: appeal2, created_at: 1.day.ago)
+    end
+
+    it "orders correctly" do
+      expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
+      expect(subject.first).to eq(@newest)
+      expect(subject.last).to eq(@oldest)
+    end
+  end
+
+  context ".unassigned" do
+    subject { Task.unassigned }
+
+    it "filters by user_id" do
+      expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
+      expect(subject.to_sql).to include("\"tasks\".\"user_id\" IS NULL")
     end
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,40 +1,55 @@
+class FakeTask < Task
+end
+
 describe Task do
   before do
     reset_application!
+
+    appeal = Appeal.create(vacols_id: "123C")
+    appeal2 = Appeal.create(vacols_id: "456D")
+    @task1 = CreateEndProduct.create(appeal: appeal)
+    @task2 = CreateEndProduct.create(appeal: appeal2)
   end
 
   context ".find_by_department" do
+    before do
+      appeal = Appeal.create(vacols_id: "fake")
+      FakeTask.create(appeal: appeal)
+    end
     let(:department) { :dispatch }
     subject { Task.find_by_department(department) }
 
     it "filters to tasks in the department" do
       expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
-      expect(subject.to_sql).to include("\"tasks\".\"type\" = 'CreateEndProduct'")
+      expect(Task.count).to eq(3)
+      expect(subject.count).to eq(2)
     end
   end
 
   context ".newest_first" do
     subject { Task.newest_first }
     before do
-      appeal = Appeal.create(vacols_id: "123C")
-      appeal2 = Appeal.create(vacols_id: "456D")
-      @oldest = CreateEndProduct.create(appeal: appeal, created_at: 10.days.ago)
-      @newest = CreateEndProduct.create(appeal: appeal2, created_at: 1.day.ago)
+      @task1.update(created_at: 10.days.ago)
+      @task2.update(created_at: 1.day.ago)
     end
 
     it "orders correctly" do
       expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
-      expect(subject.first).to eq(@newest)
-      expect(subject.last).to eq(@oldest)
+      expect(subject.first).to eq(@task2)
+      expect(subject.last).to eq(@task1)
     end
   end
 
   context ".unassigned" do
+    before do
+      @task1.update(user: User.create(css_id: "111", station_id: "abc"))
+    end
     subject { Task.unassigned }
 
-    it "filters by user_id" do
+    it "filters by nil user_id" do
       expect(subject).to be_an_instance_of(Task::ActiveRecord_Relation)
-      expect(subject.to_sql).to include("\"tasks\".\"user_id\" IS NULL")
+      expect(subject.count).to eq(1)
+      expect(subject.first).to eq(@task2)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,10 @@ module StubbableUser
         })
     end
 
+    def current_user
+      @stub
+    end
+
     def unauthenticate!
       self.stub = nil
     end
@@ -75,9 +79,15 @@ end
 User.prepend(StubbableUser)
 
 def reset_application!
+  Task.delete_all
+  Appeal.delete_all
   User.clear_stub!
   User.delete_all
   Certification.delete_all
+end
+
+def current_user
+  User.current_user
 end
 
 # Setup fakes


### PR DESCRIPTION
This PR adds the initial case worker landing page which includes:
- call-to-action button "Create End Product"

Fixes #388 

Testing:
- All current tests pass
- Added new unit & feature tests
- Manually tested in browser by navigating to `/dispatch`:
<img width="1417" alt="screen shot 2016-11-07 at 9 50 14 am" src="https://cloud.githubusercontent.com/assets/2256237/20065667/e799273e-a4dc-11e6-80c9-95e501aec821.png">

