### PR TITLE
Allow Gem source to be overridden by env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,4 @@
-if ENV['GEM_SERVER_URL'] == nil
-  source 'https://rubygems.org'
-else
-  source ENV['GEM_SERVER_URL']
-end
-
+source ENV['GEM_SERVER_URL'] || 'https://rubygems.org'
 
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "b743c64"
 gem "moment_timezone-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
-source 'https://rubygems.org'
+if ENV["GEM_SERVER_URL"] == nil
+  source 'https://rubygems.org'
+elseb
+  source ENV["GEM_SERVER_URL"]
 
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "b743c64"
 gem "moment_timezone-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,11 @@
-if ENV["GEM_SERVER_URL"] == nil
+if ENV['GEM_SERVER_URL'] == nil
   puts "using gemserver ruby"
   source 'https://rubygems.org'
 else
-  puts "using gemserver #{ENV["GEM_SERVER_URL"]}"
-  source ENV["GEM_SERVER_URL"]
+  puts "using gemserver #{ENV['GEM_SERVER_URL']}"
+  source ENV['GEM_SERVER_URL']
+end
+
 
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "b743c64"
 gem "moment_timezone-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 if ENV['GEM_SERVER_URL'] == nil
-  puts "using gemserver ruby"
   source 'https://rubygems.org'
 else
-  puts "using gemserver #{ENV['GEM_SERVER_URL']}"
   source ENV['GEM_SERVER_URL']
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 if ENV["GEM_SERVER_URL"] == nil
+  puts "using gemserver ruby"
   source 'https://rubygems.org'
-elseb
+else
+  puts "using gemserver #{ENV["GEM_SERVER_URL"]}"
   source ENV["GEM_SERVER_URL"]
 
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "b743c64"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node {
     // Checkout the deployment repo for the ansible script. This is needed
     // since the deployment scripts are separated from the source code.
     stage ('checkout-deploy-repo') {
-      sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
+      sh "git clone -b feature/gem-server https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
       dir ('./appeals-deployment/ansible') {
         sh 'git submodule init'
         sh 'git submodule update'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node {
     // Checkout the deployment repo for the ansible script. This is needed
     // since the deployment scripts are separated from the source code.
     stage ('checkout-deploy-repo') {
-      sh "git clone -b feature/gem-server https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
+      sh "git clone https://${env.GIT_CREDENTIAL}@github.com/department-of-veterans-affairs/appeals-deployment"
       dir ('./appeals-deployment/ansible') {
         sh 'git submodule init'
         sh 'git submodule update'


### PR DESCRIPTION
Allow gem source to be overridden by `GEM_SERVER_URL`. This URL will port to an internal gem server in deployment scripts.

See also https://github.com/department-of-veterans-affairs/appeals-deployment/pull/198